### PR TITLE
fixed up our GET routes

### DIFF
--- a/server/app/routes/category/index.js
+++ b/server/app/routes/category/index.js
@@ -5,7 +5,6 @@ var Product = mongoose.model('Product');
 
 router.get('/', function(req, res, next) {
 	Product.getAllCategories().then(function (data) {
-		console.log(data);
 		res.json(data);
 	});
 });

--- a/server/app/routes/index.js
+++ b/server/app/routes/index.js
@@ -2,10 +2,9 @@
 var router = require('express').Router();
 module.exports = router;
 
-router.use('/product', require('./product'));
-router.use('/category', require('./category'));
-router.use('/user', require('./user'));
-router.use('/order', require('./order'));
+router.use('/products', require('./product'));
+router.use('/categories', require('./category'));
+router.use('/users', require('./user'));
 
 // Make sure this is after all of
 // the registered routes!

--- a/server/app/routes/user/index.js
+++ b/server/app/routes/user/index.js
@@ -3,11 +3,11 @@ var router = require('express').Router();
 var mongoose = require('mongoose')
 var User = mongoose.model('User');
 
-router.use('/', function(req, res, next) {
-	res.status(403).end();
-});
+router.use('/:id/orders', require('../order'));
 
-router.use('/:id/order', require('../order'));
+router.get('/', function(req, res, next) {
+	res.status(403).send('Denied operation');
+});
 
 router.get('/:id', function(req, res, next) {
 	res.json(req.user)

--- a/server/db/models/product.js
+++ b/server/db/models/product.js
@@ -10,7 +10,7 @@
 
 'use strict';
 var mongoose = require('mongoose');
-var Promise = require('q');
+var q = require('q');
 
 var productSchema = new mongoose.Schema({
 	title: {
@@ -49,13 +49,23 @@ productSchema.statics.getByCategory = function(cat) {
 	return mongoose.model('Product').find({category: {"$in": [cat]}}).exec();
 }
 
+// grabs all categories, but very inneficent. Will have to make a category
+// model & collection later.
 productSchema.statics.getAllCategories = function() {
-	return ['Prada', 'Ray-Ban', 'Oakley', 'men', 'women'];
-//	return new Promise(function(resolve, reject) {
-//		mongoose.model('Product').find({}, function (products) {
-//			resolve(products);
-//		});
-//	})
+	return q.ninvoke(Product, 'find', {}).then(function(products) {
+		var categories = [];
+		products.forEach(function(element) {
+
+			element.category.forEach(function(category) {
+				if (categories.indexOf(category) === -1) {
+					categories.push(category);
+				}
+			});
+
+		});
+
+		return categories;
+	});
 }
 
 var Product = mongoose.model('Product', productSchema);


### PR DESCRIPTION
- fixed getAllCategories() function to actually grab all categories. This is inefficient and we will need a separate Category model eventually. 

- changed routes to plural nouns instead. That looks to be the correct way to name RESTful routes.

- 403 error is correctly seen when going to localhost/api/users

- order routes are no longer mounted to localhost/api. Going to localhost/api/orders would cause an error as res.user will not be defined. You have to go to /api/users/:id/orders to see all orders of a user.